### PR TITLE
Fix setuptools install to recursively install all package directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 version = '0.1'
 
@@ -14,7 +14,7 @@ setup(name='ramp',
       author_email='kvh@science.io',
       url='http://github.com/kvh/ramp',
       license='BSD',
-      packages=['ramp'],
+      packages=find_packages(exclude=["*.tests"]),
       zip_safe=False,
       install_requires=[
           'numpy',


### PR DESCRIPTION
Fixes a bug where setuptools would only install the `ramp` directory but not the subdirectories. Excludes tests.

Ramp can now be installed inside a virtualenv. It should also be ready for publishing in PyPi for easier installation with `pip install ramp`.
